### PR TITLE
Fixed double clipping

### DIFF
--- a/lua/autorun/server/proper_clipping.lua
+++ b/lua/autorun/server/proper_clipping.lua
@@ -255,6 +255,7 @@ end
 -- Clips from https://steamcommunity.com/sharedfiles/filedetails/?id=106753151
 duplicator.RegisterEntityModifier("clips", function(ply, ent, data)
 	if not ent or not ent:IsValid() then return end
+	if ent.EntityMods.proper_clipping then return end -- Already using the newer method, abort.
 	
 	if not hook.Run("CanTool", ply, {Entity = ent}, "proper_clipping") then
 		ply:ChatPrint("Not allowed to create visual clips, " .. tostring(ent) .. " will be spawned without any.")


### PR DESCRIPTION
Freshly clipped entities would be clipped twice on dupe spawn due to both entity modifier methods being applied on them. With this PR, the old `clips` entity modifier will be aborted if the entity also contains the newer `proper_clipping` entity modifier.