### PR TITLE
Fixed client-side full update and hitbox

### DIFF
--- a/lua/autorun/client/proper_clipping.lua
+++ b/lua/autorun/client/proper_clipping.lua
@@ -51,11 +51,11 @@ function ProperClipping.AddVisualClip(ent, norm, dist, inside, physics)
 	if not ent.Clipped then
 		ent.RenderOverride_preclipping = ent.RenderOverride
 		ent.RenderOverride = renderOverride
-
+		
 		ent.Clipped = true
 		ent.ClipData = {}
 	end
-
+	
 	table.insert(ent.ClipData, {
 		origin = norm * dist,
 		norm = norm,
@@ -83,22 +83,21 @@ local clip_queue = {}
 
 local function attemptClip(id, clips)
 	local ent = Entity(id)
-
 	if not IsValid(ent) then return false end
-
+	
 	ProperClipping.RemoveVisualClips(ent)
 	ProperClipping.ResetPhysics(ent)
-
+	
 	for _, clip in ipairs(clips) do
 		local norm, dist, inside, physics = unpack(clip)
-
+		
 		ProperClipping.AddVisualClip(ent, norm, dist, inside, physics)
-
+		
 		if physics then
 			ProperClipping.ClipPhysics(ent, norm, dist)
 		end
 	end
-
+	
 	return true
 end
 
@@ -113,22 +112,21 @@ end)
 net.Receive("proper_clipping", function()
 	local id = net.ReadUInt(14)
 	local add = net.ReadBool()
-
+	
 	if not add then
 		clip_queue[id] = nil
-
+		
 		local ent = Entity(id)
-
 		if IsValid(ent) then return end
-
+		
 		ProperClipping.RemoveVisualClips(ent)
 		ProperClipping.ResetPhysics(ent)
-
+		
 		return
 	end
-
+	
 	local clips = {}
-
+	
 	for i = 1, net.ReadUInt(4) do
 		clips[i] = {
 			Vector(net.ReadFloat(), net.ReadFloat(), net.ReadFloat()),
@@ -137,7 +135,7 @@ net.Receive("proper_clipping", function()
 			net.ReadBool()
 		}
 	end
-
+	
 	if not attemptClip(id, clips) then
 		clip_queue[id] = clips
 	end

--- a/lua/autorun/server/proper_clipping.lua
+++ b/lua/autorun/server/proper_clipping.lua
@@ -169,17 +169,27 @@ end
 ----------------------------------------
 
 hook.Add("PlayerInitialSpawn", "proper_clipping", function(ply)
-	timer.Simple(10, function()
-		if not IsValid(ply) then return end
-
+	local id = "proper_clipping_" .. ply:EntIndex()
+	hook.Add("SetupMove", id, function(ply2, _, cmd)
+		if not ply:IsValid() then
+			hook.Remove("SetupMove", id)
+			
+			return
+		end
+		
+		if ply ~= ply2 then return end
+		if cmd:IsForced() then return end
+		
 		local ent_count, clip_count = 0, 0
-		for ent in pairs(ProperClipping.ClippedEntities) do
+		for ent, _ in pairs(ProperClipping.ClippedEntities) do
 			ProperClipping.NetworkClips(ent, ply)
 			ent_count = ent_count + 1
 			clip_count = clip_count + #ent.ClipData
 		end
-
+		
 		print("Sending " .. clip_count .. " clips from " .. ent_count .. " entities to " .. ply:GetName())
+		
+		hook.Remove("SetupMove", id)
 	end)
 end)
 

--- a/lua/autorun/server/proper_clipping.lua
+++ b/lua/autorun/server/proper_clipping.lua
@@ -181,7 +181,7 @@ hook.Add("PlayerInitialSpawn", "proper_clipping", function(ply)
 		if cmd:IsForced() then return end
 		
 		local ent_count, clip_count = 0, 0
-		for ent, _ in pairs(ProperClipping.ClippedEntities) do
+		for ent in pairs(ProperClipping.ClippedEntities) do
 			ProperClipping.NetworkClips(ent, ply)
 			ent_count = ent_count + 1
 			clip_count = clip_count + #ent.ClipData

--- a/lua/autorun/server/proper_clipping.lua
+++ b/lua/autorun/server/proper_clipping.lua
@@ -169,30 +169,19 @@ end
 ----------------------------------------
 
 hook.Add("PlayerInitialSpawn", "proper_clipping", function(ply)
-	local id = "proper_clipping_" .. ply:EntIndex()
-	hook.Add("CreateMove", id, function(ply2, _, cmd)
-		if not ply:IsValid() then
-			hook.Remove("CreateMove", id)
-			
-			return
-		end
-		
-		if ply ~= ply2 then return end
-		if cmd:IsForced() then return end
-		
+	timer.Simple(10, function()
+		if not IsValid(ply) then return end
+
 		local ent_count, clip_count = 0, 0
-		for ent, _ in pairs(ProperClipping.ClippedEntities) do
+		for ent in pairs(ProperClipping.ClippedEntities) do
 			ProperClipping.NetworkClips(ent, ply)
 			ent_count = ent_count + 1
 			clip_count = clip_count + #ent.ClipData
 		end
-		
+
 		print("Sending " .. clip_count .. " clips from " .. ent_count .. " entities to " .. ply:GetName())
-		
-		hook.Remove("CreateMove", id)
 	end)
 end)
-
 
 ----------------------------------------
 


### PR DESCRIPTION
- Fixed entities losing their client-side physics object in cases where the server "thinks" it's being closed, ie near server crash or manually calling `cl_fullupdate`.
- Clips will now store their physical state on the client-side.
- Fixed client-side hit-box not reflecting the actual server-side physical object hit-box.
- Fixed PlayerInitialSpawn synchronization. Players were never receiving the existing clips due to the CreateMove hook not existing on the server-side, it was instead replaced by a simple timer of 10 seconds.