### PR TITLE
Fixed physical clip duping

### DIFF
--- a/lua/autorun/client/proper_clipping.lua
+++ b/lua/autorun/client/proper_clipping.lua
@@ -7,7 +7,6 @@ local cvar_clips = CreateConVar("proper_clipping_max_visual", "6", FCVAR_ARCHIVE
 local function renderOverride(self)
 	if not self or not self:IsValid() then return end
 	if not self.Clipped or not self.ClipData then return end
-	if #self.ClipData == 0 then return end
 	
 	local prev = render.EnableClipping(true)
 	local max = cvar_clips:GetInt()
@@ -68,7 +67,7 @@ function ProperClipping.AddVisualClip(ent, norm, dist, inside, physics)
 end
 
 function ProperClipping.RemoveVisualClips(ent)
-	if ent.RenderOverride_preclipping == true then return end
+	if not ent.Clipped then return end
 	
 	ent.Clipped = nil
 	ent.ClipData = nil
@@ -117,7 +116,8 @@ net.Receive("proper_clipping", function()
 		clip_queue[id] = nil
 		
 		local ent = Entity(id)
-		if IsValid(ent) then return end
+
+		if not IsValid(ent) then return end
 		
 		ProperClipping.RemoveVisualClips(ent)
 		ProperClipping.ResetPhysics(ent)

--- a/lua/autorun/client/proper_clipping.lua
+++ b/lua/autorun/client/proper_clipping.lua
@@ -116,7 +116,6 @@ net.Receive("proper_clipping", function()
 		clip_queue[id] = nil
 		
 		local ent = Entity(id)
-
 		if not IsValid(ent) then return end
 		
 		ProperClipping.RemoveVisualClips(ent)

--- a/lua/autorun/proper_clipping.lua
+++ b/lua/autorun/proper_clipping.lua
@@ -180,6 +180,7 @@ function ProperClipping.ClipPhysics(ent, norm, dist)
 	if not meshes then return end
 	
 	ent.PhysicsClipped = true
+	ent.OBBCenterOrg = ent.OBBCenterOrg or ent:OBBCenter()
 	
 	-- Store properties to copy over to the new physobj
 	local data = ProperClipping.GetPhysObjData(physobj)
@@ -224,6 +225,7 @@ function ProperClipping.ResetPhysics(ent)
 	if not ent.PhysicsClipped then return end
 	
 	ent.PhysicsClipped = nil
+	ent.OBBCenterOrg = nil
 	
 	local physobj = ent:GetPhysicsObject()
 	local data = IsValid(physobj) and ProperClipping.GetPhysObjData(physobj)


### PR DESCRIPTION
It's pretty much the same as #3, along with a few other smaller fixes, except now I can be a bit more specific about the reason why this PR is being created. Here's a short video showing the problem:

[![Physical clip dupe issue](http://cdn-cf-east.streamable.com/image/4twblt.jpg)](https://streamable.com/4twblt)

On the video, the entity on the left side will be physically clipped while the one on the right will be only clipped visually. As we dupe these two entities, the physical clip will slowly climb the entity on the left, while the one on the right remains the same. As EPOE reports on the top right of my screen, both old `clips` and new `proper_clipping` clips will be added to the physically clipped entity, while this doesn't happen on the visually clipped entity.

Along with solving this issue, I commented out on #3 that it seems pointless to check both entity modifiers if the newer one happens to exist, since we can assume both should be the exact same.

In resume:
- Fixed physical clip creation on newly clipped entities.
- Fixed max physical clip limit not being announced to the player at all.
- Fixed clip removal not being processed properly on the client-side after being networked.