### PR TITLE
Improve backwards compatibility

### DIFF
--- a/lua/autorun/client/proper_clipping.lua
+++ b/lua/autorun/client/proper_clipping.lua
@@ -27,7 +27,7 @@ local function renderOverride(self)
 			local norm = Vector(clip.norm)
 			norm:Rotate(ang)
 			
-			render.PushCustomClipPlane(norm, norm:Dot(pos + norm * clip.d))
+			render.PushCustomClipPlane(norm, norm:Dot(pos + norm * clip.dist))
 		end
 	end
 	
@@ -54,12 +54,15 @@ function ProperClipping.AddVisualClip(ent, norm, dist, inside, physics)
 		ent.Clipped = true
 		ent.ClipData = {}
 	end
-	
+
+	local Center = ent.OBBCenterOrg or ent:OBBCenter()
+
 	table.insert(ent.ClipData, {
 		origin = norm * dist,
 		norm = norm,
 		n = norm:Angle(),
-		d = dist,
+		dist = dist,
+		d = norm:Dot(norm * dist - Center),
 		inside = inside,
 		physics = physics,
 		new = true -- still no clue what this is for, meh w/e

--- a/lua/autorun/client/proper_clipping.lua
+++ b/lua/autorun/client/proper_clipping.lua
@@ -54,15 +54,13 @@ function ProperClipping.AddVisualClip(ent, norm, dist, inside, physics)
 		ent.Clipped = true
 		ent.ClipData = {}
 	end
-
-	local Center = ent.OBBCenterOrg or ent:OBBCenter()
-
+	
 	table.insert(ent.ClipData, {
 		origin = norm * dist,
 		norm = norm,
 		n = norm:Angle(),
 		dist = dist,
-		d = norm:Dot(norm * dist - Center),
+		d = norm:Dot(norm * dist - (ent.OBBCenterOrg or ent:OBBCenter())),
 		inside = inside,
 		physics = physics,
 		new = true -- still no clue what this is for, meh w/e

--- a/lua/autorun/proper_clipping.lua
+++ b/lua/autorun/proper_clipping.lua
@@ -47,7 +47,7 @@ if CLIENT then
 		if ent.PhysicsClipped then
 			for _, clip in ipairs(ent.ClipData) do
 				if clip.physics then
-					ProperClipping.ClipPhysics(ent, clip.norm, clip.d)
+					ProperClipping.ClipPhysics(ent, clip.norm, clip.dist)
 				end
 			end
 		end

--- a/lua/autorun/server/proper_clipping.lua
+++ b/lua/autorun/server/proper_clipping.lua
@@ -23,14 +23,12 @@ function ProperClipping.AddClip(ent, norm, dist, inside, physics)
 	ent.ClipData = ent.ClipData or {}
 	
 	if #ent.ClipData >= cvar_visuals:GetInt() then return false end
-
-	local Center = ent.OBBCenterOrg or ent:OBBCenter()
-
+	
 	table.insert(ent.ClipData, {
 		norm = norm,
 		n = norm:Angle(),
 		dist = dist,
-		d = norm:Dot(norm * dist - Center),
+		d = norm:Dot(norm * dist - (ent.OBBCenterOrg or ent:OBBCenter())),
 		inside = inside,
 		physics = physics, -- this is used to network and call on client automaticly
 		new = true -- whats this used for? no clue but lets add it anyways


### PR DESCRIPTION
There's a few addons that still rely on the old OBBCenter-based clip position. This PR renames the current distance field to `dist`, along with making all the pertinent changes to the code to supoort this, and also adds a legacy `d` distance field that still uses the old OBBCenter method.

- Renamed distance field on ClipData to `dist`.
- Added legacy distance `d` field for addons that still rely on the OBBCenter clip position method.