### PR TITLE
Optimized constraint rebuilding

### DIFF
--- a/lua/autorun/proper_clipping.lua
+++ b/lua/autorun/proper_clipping.lua
@@ -17,7 +17,8 @@ ProperClipping = ProperClipping or {
 }
 
 local cvar_physics = CreateConVar("proper_clipping_max_physics", "2", FCVAR_ARCHIVE, "Max physical clips a entity can have", 0, 8)
-
+local Constraints = duplicator.ConstraintType
+local ClippedPhysics = ProperClipping.ClippedPhysics
 local class_whitelist = {
 	prop_physics = true
 }
@@ -27,11 +28,13 @@ local class_whitelist = {
 if CLIENT then
 	
 	hook.Add("Think", "proper_clipping_physics", function()
-		for ent in pairs(ProperClipping.ClippedPhysics) do
+		for ent in pairs(ClippedPhysics) do
+			if not IsValid(ent) then ClippedPhysics[ent] = nil end
+
 			local physobj = ent:GetPhysicsObject()
 			
 			if not IsValid(physobj) then
-				ProperClipping.ClippedPhysics[ent] = nil
+				ClippedPhysics[ent] = nil
 			else
 				physobj:SetPos(ent:GetPos())
 				physobj:SetAngles(ent:GetAngles())
@@ -40,7 +43,7 @@ if CLIENT then
 	end)
 	
 	hook.Add("PhysgunPickup", "proper_clipping_physics", function(_, ent)
-		if ProperClipping.ClippedPhysics[ent] then return false end
+		if ClippedPhysics[ent] then return false end
 	end)
 	
 	hook.Add("NetworkEntityCreated", "proper_clipping_physics", function(ent)
@@ -125,41 +128,38 @@ function ProperClipping.CanAddPhysicsClip(ent, ply)
 	return ProperClipping.PhysicsClipsLeft(ent)
 end
 
-function ProperClipping.GetPhysObjData(physobj)
-	local constraints, constraint_ents = {}, {}
-	
-	if SERVER then
-		duplicator.GetAllConstrainedEntitiesAndConstraints(physobj:GetEntity(), constraint_ents, constraints)
-	end
-	
+function ProperClipping.GetPhysObjData(ent, physobj)
 	return {
 		vol = physobj:GetVolume(),
 		mass = physobj:GetMass(),
 		mat = physobj:GetMaterial(),
 		contents = physobj:GetContents(),
 		motion = physobj:IsMotionEnabled(),
-		
-		constraints = constraints,
-		constraint_ents = constraint_ents
+		constraints = SERVER and constraint.GetTable(ent) or nil
 	}
 end
 
-function ProperClipping.ApplyPhysObjData(physobj, data)
-	physobj:SetMass(math.max(1, physobj:GetVolume() / data.vol * data.mass))
-	physobj:SetMaterial(data.mat)
-	physobj:SetContents(data.contents)
-	
+function ProperClipping.ApplyPhysObjData(physobj, physdata)
+	physobj:SetMass(math.max(1, physobj:GetVolume() / physdata.vol * physdata.mass))
+	physobj:SetMaterial(physdata.mat)
+	physobj:SetContents(physdata.contents)
+
 	if SERVER then
-		physobj:EnableMotion(data.motion)
-		if data.motion then
+		physobj:EnableMotion(physdata.motion)
+		if physdata.motion then
 			physobj:Wake()
 		end
-		
-		timer.Simple(0, function()
-			for id, constraint in pairs(data.constraints) do
-				duplicator.CreateConstraintFromTable(constraint, data.constraint_ents)
+
+		for _, Data in ipairs(physdata.constraints) do
+			local Constraint = Constraints[Data.Type]
+			local Args = {}
+
+			for Index, Name in ipairs(Constraint.Args) do
+				Args[Index] = Data[Name]
 			end
-		end)
+
+			Constraint.Func(unpack(Args)) -- Forcing constraints to create themselves again
+		end
 	else
 		physobj:EnableMotion(false)
 		physobj:Sleep()
@@ -187,7 +187,7 @@ function ProperClipping.ClipPhysics(ent, norm, dist)
 	ent.OBBCenterOrg = ent.OBBCenterOrg or ent:OBBCenter()
 	
 	-- Store properties to copy over to the new physobj
-	local data = ProperClipping.GetPhysObjData(physobj)
+	local data = ProperClipping.GetPhysObjData(ent, physobj)
 	
 	-- Cull stuff
 	if type(dist) ~= "table" then
@@ -232,10 +232,10 @@ function ProperClipping.ClipPhysics(ent, norm, dist)
 	ProperClipping.ApplyPhysObjData(physobj, data)
 	
 	if CLIENT then
-		ProperClipping.ClippedPhysics[ent] = physobj
+		ClippedPhysics[ent] = physobj
 		
 		ent:CallOnRemove("proper_clipping", function()
-			ProperClipping.ClippedPhysics[ent] = nil
+			ClippedPhysics[ent] = nil
 		end)
 	end
 	
@@ -249,7 +249,7 @@ function ProperClipping.ResetPhysics(ent)
 	ent.OBBCenterOrg = nil
 	
 	local physobj = ent:GetPhysicsObject()
-	local data = IsValid(physobj) and ProperClipping.GetPhysObjData(physobj)
+	local data = IsValid(physobj) and ProperClipping.GetPhysObjData(ent, physobj)
 	
 	-- Amazing hack that fixes the physics object, why does this work?
 	ent:SetModel(ent:GetModel())
@@ -265,7 +265,7 @@ function ProperClipping.ResetPhysics(ent)
 	end
 	
 	if CLIENT then
-		ProperClipping.ClippedPhysics[ent] = physobj
+		ClippedPhysics[ent] = physobj
 	end
 	
 	hook.Run("ProperClippingPhysicsReset", ent)


### PR DESCRIPTION
Optimizes the constraint rebuilding process whenever the physics object of a clipped entities is modified by just rebuilding the constraints of the affected entity. This will vastly decrease the impact on the server whenever a big amount of constrained physically clipped entities are spawned at once (ie when pasting a dupe). Should deal with #11.

- Optimized constraint rebuilding to only affect the constraints of the entity that was physically modified.
- Added a small check for invalid entities on the `ProperClipping.ClippedPhysics` table.