### PR TITLE
Update proper_clipping.lua

### DIFF
--- a/lua/weapons/gmod_tool/stools/proper_clipping.lua
+++ b/lua/weapons/gmod_tool/stools/proper_clipping.lua
@@ -263,7 +263,7 @@ if CLIENT then
 
 	local debugwhite = Material("models/debug/debugwhite")
 
-	local function DrawPreviewModel( self )
+	local function DrawPreviewModel(self)
 		if isentity(self.GetRenderMesh) then
 			render.ModelMaterialOverride(debugwhite)
 			self.GetRenderMesh:DrawModel()

--- a/lua/weapons/gmod_tool/stools/proper_clipping.lua
+++ b/lua/weapons/gmod_tool/stools/proper_clipping.lua
@@ -260,7 +260,20 @@ if CLIENT then
 	model2:SetMaterial("models/debug/debugwhite")
 	model1:SetNoDraw(true)
 	model2:SetNoDraw(true)
-	
+
+	local debugwhite = Material("models/debug/debugwhite")
+
+	local function DrawPreviewModel( self )
+		if isentity(self.GetRenderMesh) then
+			render.ModelMaterialOverride(debugwhite)
+			self.GetRenderMesh:DrawModel()
+			render.ModelMaterialOverride(nil)
+			return
+		end
+
+		self:DrawModel()
+	end
+
 	local last_ent
 	
 	hook.Add("PostDrawOpaqueRenderables", "proper_clipping", function(depth, skybox)
@@ -327,6 +340,9 @@ if CLIENT then
 						model1:SetBodygroup(id, val)
 						model2:SetBodygroup(id, val)
 					end
+
+					model1.GetRenderMesh = isfunction( ent.GetRenderMesh ) and ent or nil
+					model2.GetRenderMesh = isfunction( ent.GetRenderMesh ) and ent or nil
 				end
 				
 				ent:SetNoDraw(true)
@@ -338,12 +354,12 @@ if CLIENT then
 				
 				render.PushCustomClipPlane(norm * (i and 1 or -1), norm:Dot(origin) * (i and 1 or -1) - offset)
 				render.SetColorModulation(0.3, 2, 0.5)
-				model1:DrawModel()
+				DrawPreviewModel( model1 )
 				render.PopCustomClipPlane()
 				
 				render.PushCustomClipPlane(norm * (i and -1 or 1), norm:Dot(origin) * (i and -1 or 1) + offset)
 				render.SetColorModulation(2, 0.2, 0.3)
-				model2:DrawModel()
+				DrawPreviewModel( model2 )
 				render.PopCustomClipPlane()
 				
 				render.EnableClipping(prev)

--- a/lua/weapons/gmod_tool/stools/proper_clipping.lua
+++ b/lua/weapons/gmod_tool/stools/proper_clipping.lua
@@ -341,8 +341,8 @@ if CLIENT then
 						model2:SetBodygroup(id, val)
 					end
 
-					model1.GetRenderMesh = isfunction( ent.GetRenderMesh ) and ent or nil
-					model2.GetRenderMesh = isfunction( ent.GetRenderMesh ) and ent or nil
+					model1.GetRenderMesh = isfunction(ent.GetRenderMesh) and ent or nil
+					model2.GetRenderMesh = isfunction(ent.GetRenderMesh) and ent or nil
 				end
 				
 				ent:SetNoDraw(true)
@@ -354,12 +354,12 @@ if CLIENT then
 				
 				render.PushCustomClipPlane(norm * (i and 1 or -1), norm:Dot(origin) * (i and 1 or -1) - offset)
 				render.SetColorModulation(0.3, 2, 0.5)
-				DrawPreviewModel( model1 )
+				DrawPreviewModel(model1)
 				render.PopCustomClipPlane()
 				
 				render.PushCustomClipPlane(norm * (i and -1 or 1), norm:Dot(origin) * (i and -1 or 1) + offset)
 				render.SetColorModulation(2, 0.2, 0.3)
-				DrawPreviewModel( model2 )
+				DrawPreviewModel(model2)
 				render.PopCustomClipPlane()
 				
 				render.EnableClipping(prev)


### PR DESCRIPTION
The clientside preview ents  currently only handle DrawModel, what that means is the preview will show the entity's base model instead of the mesh. This adds a check and an override for GetRenderMesh. 

This was only tested on my Primitive addon ents, but it should work for any ent that has a GetRenderMesh method.