### PR TITLE
Fix blank constraint types causing dupes to not spawn

### DIFF
--- a/lua/autorun/proper_clipping.lua
+++ b/lua/autorun/proper_clipping.lua
@@ -160,6 +160,7 @@ function ProperClipping.ApplyPhysObjData(physobj, physdata, keepmass)
 		end
 		
 		for _, data in ipairs(physdata.constraints) do
+			if data.Type == "" then continue end
 			local con = dConstraints[data.Type]
 			local args = {}
 			local id = ""


### PR DESCRIPTION
Not sure what causes this to happen but I've been sent a few dupes where the constraint type is simply an empty string, which ends up causing an error not allowing them to fully spawn.