### PR TITLE
Fix prediction of TOOL:LeftClick for modes 2 & 3

### DIFF
--- a/lua/weapons/gmod_tool/stools/proper_clipping.lua
+++ b/lua/weapons/gmod_tool/stools/proper_clipping.lua
@@ -168,6 +168,9 @@ function TOOL:LeftClick(tr)
 		if not ent or not ent:IsValid() then return end
 		if ent:IsPlayer() or ent:IsWorld() then return end
 	end
+	if op == 3 then return end
+	
+	if not IsFirstTimePredicted() then return true end
 	
 	if op == 0 then
 		self.norm = tr.HitNormal


### PR DESCRIPTION
- Fixes incorrect client side preview for mode 2 "2 Hitplanes intersection", caused by repetitive assignment of self.plane when left click is predicted. When I implemented mode 2, I didn't test it on a non-local server where prediction kicks in. Oops
- Disables tool gun animation for mode 3 "Pitch and Yaw", as left click is unused for this mode