### PR TITLE
Optimizations

### DIFF
--- a/lua/autorun/proper_clipping.lua
+++ b/lua/autorun/proper_clipping.lua
@@ -27,26 +27,35 @@ local class_whitelist = {
 
 if CLIENT then
 	
-	hook.Add("Think", "proper_clipping_physics", function()
-		for ent in pairs(clippedPhysics) do
-			if not IsValid(ent) then
-				clippedPhysics[ent] = nil
-			else
-				local physobj = ent:GetPhysicsObject()
-				if not IsValid(physobj) then
+	local function addHook()
+		hook.Add("Think", "proper_clipping_physics", function()
+			for ent in pairs(clippedPhysics) do
+				if not IsValid(ent) then
 					clippedPhysics[ent] = nil
 				else
-					physobj:SetPos(ent:GetPos())
-					physobj:SetAngles(ent:GetAngles())
+					local physobj = ent:GetPhysicsObject()
+					if not IsValid(physobj) then
+						clippedPhysics[ent] = nil
+					else
+						physobj:SetPos(ent:GetPos())
+						physobj:SetAngles(ent:GetAngles())
+					end
 				end
 			end
-		end
-	end)
-	
+		end)
+	end
+
 	hook.Add("PhysgunPickup", "proper_clipping_physics", function(_, ent)
-		if clippedPhysics[ent] then return false end
+		if not clippedPhysics[ent] then return end
+		addHook()
+		return false
 	end)
-	
+
+	hook.Add("PhysgunDrop", "proper_clipping_physics", function(_, ent)
+		if not clippedPhysics[ent] then return end
+		hook.Remove("Think", "proper_clipping_physics" )
+	end)
+
 	hook.Add("NetworkEntityCreated", "proper_clipping_physics", function(ent)
 		if ent.PhysicsClipped then
 			for _, clip in ipairs(ent.ClipData) do


### PR DESCRIPTION
Reduces the amount of __index calls to improve performance, currently this addon calls it an absolute truckload which causes fps lag when a build has a lot of clips. Example of the effect of this change <https://github.com/Facepunch/garrysmod/pull/2010>
Also only adds the physgun hook when it's actually needed.

We've been using this change on our server for a good while now and it works fine 