### PR TITLE
e2function table entity:getClipData()

### DIFF
--- a/lua/entities/gmod_wire_expression2/core/custom/cl_proper_clipping.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_proper_clipping.lua
@@ -8,3 +8,4 @@ E2Helper.Descriptions["removeClipByIndex(e:n)"] = "Removes the clip on the entit
 E2Helper.Descriptions["removeClip(e:n)"]        = "Alias of removeClipByIndex(e:n); Removes the clip on the entity with number as index"
 E2Helper.Descriptions["getClipIndex(e:vv)"]     = "Returns the clip index of the entity with vector1 as origin and vector2 as normal, will be -1 if the clip doesn't exist"
 E2Helper.Descriptions["physicsClipsLeft(e:)"]   = "Returns the amount of physics clips left that can be made on the entity"
+E2Helper.Descriptions["getClipData(e:)"]        = "Returns the internal clip data of the entity as an 'array' of tables. Consists of 2 sets of clip data (norm/dist/inside/physics used by addon itself, n/d/inside/new are backwards compatibility for other addons)"

--- a/lua/entities/gmod_wire_expression2/core/custom/cl_proper_clipping.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/cl_proper_clipping.lua
@@ -8,4 +8,4 @@ E2Helper.Descriptions["removeClipByIndex(e:n)"] = "Removes the clip on the entit
 E2Helper.Descriptions["removeClip(e:n)"]        = "Alias of removeClipByIndex(e:n); Removes the clip on the entity with number as index"
 E2Helper.Descriptions["getClipIndex(e:vv)"]     = "Returns the clip index of the entity with vector1 as origin and vector2 as normal, will be -1 if the clip doesn't exist"
 E2Helper.Descriptions["physicsClipsLeft(e:)"]   = "Returns the amount of physics clips left that can be made on the entity"
-E2Helper.Descriptions["getClipData(e:)"]        = "Returns the internal clip data of the entity as an 'array' of tables. Consists of 2 sets of clip data (norm/dist/inside/physics used by addon itself, n/d/inside/new are backwards compatibility for other addons)"
+E2Helper.Descriptions["getClipData(e:)"]        = "Returns the clip data of the entity as an 'array'(table with numbers for keys) of tables. If the entity has no clips, it will return an empty table"

--- a/lua/entities/gmod_wire_expression2/core/custom/proper_clipping.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/proper_clipping.lua
@@ -113,24 +113,18 @@ e2function table entity:getClipData()
 	for key, tbl in ipairs(this.ClipData) do
 		nestedTbl = {
 			s = {
-				d = tbl.d,
-				dist = tbl.dist,
-				inside = tbl.inside and 1 or 0,
-				n = tbl.n,
-				new = tbl.new and 1 or 0,
-				norm = tbl.norm,
-				physics = tbl.physics and 1 or 0
+				distance = tbl.dist,
+				isInside = tbl.inside and 1 or 0,
+				normal = tbl.norm,
+				isPhysics = tbl.physics and 1 or 0
 			},
 			stypes = {
-				d = "s",
-				dist = "n",
-				inside = "n",
-				n = "v",
-				new = "n",
-				norm = "v",
-				physics = "n"
+				distance = "n",
+				isInside = "n",
+				normal = "v",
+				isPhysics = "n"
 			},
-			size = #tbl,
+			size = 4,
 			n = {},
 			ntypes = {}
 		}

--- a/lua/entities/gmod_wire_expression2/core/custom/proper_clipping.lua
+++ b/lua/entities/gmod_wire_expression2/core/custom/proper_clipping.lua
@@ -105,3 +105,40 @@ end
 e2function number entity:physicsClipsLeft()
 	return ProperClipping.PhysicsClipsLeft(this)
 end
+
+e2function table entity:getClipData()
+	if not this.ClipData then return E2Lib.newE2Table() end
+	local res = E2Lib.newE2Table()
+
+	for key, tbl in ipairs(this.ClipData) do
+		nestedTbl = {
+			s = {
+				d = tbl.d,
+				dist = tbl.dist,
+				inside = tbl.inside and 1 or 0,
+				n = tbl.n,
+				new = tbl.new and 1 or 0,
+				norm = tbl.norm,
+				physics = tbl.physics and 1 or 0
+			},
+			stypes = {
+				d = "s",
+				dist = "n",
+				inside = "n",
+				n = "v",
+				new = "n",
+				norm = "v",
+				physics = "n"
+			},
+			size = #tbl,
+			n = {},
+			ntypes = {}
+		}
+		
+		res.n[key] = nestedTbl
+		res.ntypes[key] = "t"
+	end
+	
+	res.size = #this.ClipData
+	return res
+end


### PR DESCRIPTION
No idea why this didn't exist but getClipIndex() did, but it's really useful :D
For example, here:

```ts
@strict
const Ent = entity():isWeldedTo()
const ClipData = Ent:getClipData()[1, table]

holoCreate(1, Ent:toWorld(vec()), vec(1), Ent:toWorld(ang()), vec4(255,0,0,255), Ent:model())
holoClipEnabled(1, 1)
print(ClipData)
holoClip(1, -vec(ClipData["dist", number]), -ClipData["norm", vector], 0)
holoParent(1, Ent)

```

![2024-12-17_22-44](https://github.com/user-attachments/assets/9c5378dd-41ef-41d0-b80d-1ee55ae4616e)
