### PR TITLE
Remove hook earlier

### DIFF
--- a/lua/autorun/server/proper_clipping.lua
+++ b/lua/autorun/server/proper_clipping.lua
@@ -228,7 +228,9 @@ hook.Add("PlayerInitialSpawn", "proper_clipping", function(ply)
 		
 		if ply ~= ply2 then return end
 		if cmd:IsForced() then return end
-		
+
+		hook.Remove("SetupMove", id)
+
 		local ent_count, clip_count = 0, 0
 		for ent in pairs(ProperClipping.ClippedEntities) do
 			ProperClipping.NetworkClips(ent, ply)
@@ -239,8 +241,6 @@ hook.Add("PlayerInitialSpawn", "proper_clipping", function(ply)
 		if ent_count > 0 then
 			print("Sending " .. clip_count .. " clips from " .. ent_count .. " entities to " .. ply:GetName())
 		end
-		
-		hook.Remove("SetupMove", id)
 	end)
 end)
 


### PR DESCRIPTION
Removes the hook earlier so if the logic errors it wont spam a huge volume of errors as the hook is never removed.

The error we had repeat:
```
addons/proper_clipping/lua/autorun/server/proper_clipping.lua:236 - attempt to get length of field 'ClipData' (a nil value)
1.  __len - [C]:-1
 2.  func - addons/proper_clipping/lua/autorun/server/proper_clipping.lua:236
  3.  <unknown> - addons/ulib/lua/includes/modules/hook.lua:260
```

Likely caused by (not fixed in this PR):
```
lua/includes/extensions/entity.lua:116 - attempt to index local 'mytable' (a nil value)
1.  __index - [C]:-1
 2.  CallOnRemove - lua/includes/extensions/entity.lua:116
  3.  AddClip - addons/proper_clipping/lua/autorun/server/proper_clipping.lua:17
   4.  <unknown> - addons/proper_clipping/lua/autorun/server/proper_clipping.lua:332
```